### PR TITLE
fix UnicodeDecodeError with cyrillic file names

### DIFF
--- a/private_storage/fields.py
+++ b/private_storage/fields.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import UploadedFile
 from django.db import models
 from django.template.defaultfilters import filesizeformat
-from django.utils.encoding import smart_str
 from django.utils.translation import ugettext_lazy as _
 from .storage import private_storage
 
@@ -71,4 +70,4 @@ class PrivateFileField(models.FileField):
         if not subdirs:
             subdirs = [self.get_directory_name()]
         dirs = list(subdirs) + [self.get_filename(filename)]
-        return smart_str(os.path.join(*dirs))
+        return os.path.normpath(os.path.join(*dirs))


### PR DESCRIPTION
Please, bump new version ASAP

Django Version:	1.11.6
Exception Type:	UnicodeDecodeError
Exception Value:	
'ascii' codec can't decode byte 0xd1 in position 0: ordinal not in range(128)
Exception Location:	../site-packages/django/core/files/storage.py in get_available_name, line 79