### PR TITLE
Made it so you can set a base folder dynamically.

### DIFF
--- a/private_storage/fields.py
+++ b/private_storage/fields.py
@@ -63,8 +63,16 @@ class PrivateFileField(models.FileField):
 
         return data
 
+    def set_base_folder(self):
+        """
+        You can override this if you are wanting to dynamically change the folder a file gets uploaded to.
+
+        :return:
+        """
+        return []
+
     def generate_filename(self, instance, filename):
-        path_parts = []
+        path_parts = self.set_base_folder()
 
         if self.upload_to:
             # Support the upload_to callable that Django provides

--- a/private_storage/fields.py
+++ b/private_storage/fields.py
@@ -63,7 +63,8 @@ class PrivateFileField(models.FileField):
 
         return data
 
-    def set_base_folder(self):
+    @staticmethod
+    def set_base_folder():
         """
         You can override this if you are wanting to dynamically change the folder a file gets uploaded to.
 


### PR DESCRIPTION
This allow one to override a folder dynamically.
Why I needed it.
I run a project call https://github.com/tomturner/django-tenants  this enables a schema/tenant per customer. What I wanted to be able to do is set a base folder for each tenant uploaded data ie the tenant id. Then what I can do is use a custom permission to stop other tenants getting to other peoples data

So what I can do is this.

```
class MyPrivateFileField(PrivateFileField):
    def set_base_folder(self):
        base_folder = str(TenantLink.object.first().tenant_id)
        return [base_folder)
```  

And this custom permission

```
def private_storage_permission(private_file):
    url = private_file.relative_name.split('/')
    tenant_id = private_file.request.tenant_id
    if tenant_id != int(url[0]):
        return False

    return private_file.request.user.is_authenticated
```


