### PR TITLE
Fix coverage dependencies in tox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,6 +275,18 @@ Contributing
 This module is designed to be generic. In case there is anything you didn't like about it,
 or think it's not flexible enough, please let us know. We'd love to improve it!
 
+Running tests
+~~~~~~~~~~~~~
+
+We use tox to run the test suite on different versions locally (and travis-ci to automate the check for PRs).
+
+To tun the test suite locally, please make sure your python environment has tox and django installed::
+
+    python3.6 -m pip install tox django
+
+And then simply execute tox to run the whole test matrix::
+
+    tox
 
 .. _django-storages: https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
 .. _query parameter authentication: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,19 @@ envlist=
     py27-django{18,19,110,111},
     py36-django{18,19,110,111},
     py36-django{20},
+    py36-django{21},
+    py36-django{22},
     # py36-django-dev,
     coverage,
 
-[testenv]
+[base]
 deps =
     django-storages
     boto3
+
+[testenv]
+deps =
+    {[base]deps}
     django18: Django >= 1.8,<1.9
     django19: Django >= 1.9,<1.10
     django110: Django >= 1.10,<1.11
@@ -24,6 +30,7 @@ basepython=python3.6
 deps=
     django==1.11
     coverage
+    {[base]deps}
 commands=
     coverage erase
     coverage run --rcfile=.coveragerc runtests.py


### PR DESCRIPTION
Without this change, running `tox -e coverage` raises this sort of exception:

```python
GLOB sdist-make: /Users/pavel.savchenko/github/django-private-storage/setup.py
coverage recreate: /Users/pavel.savchenko/github/django-private-storage/.tox/coverage
coverage installdeps: django==1.11, django-storages, coverage
coverage inst: /Users/pavel.savchenko/github/django-private-storage/.tox/.tmp/package/1/django-private-storage-2.2.zip
coverage installed: coverage==4.5.3,Django==1.11,django-private-storage==2.2,django-storages==1.7.1,pytz==2019.1
coverage run-test-pre: PYTHONHASHSEED='3367763139'
coverage run-test: commands[0] | coverage erase
coverage run-test: commands[1] | coverage run --rcfile=.coveragerc runtests.py
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
../Users/pavel.savchenko/github/django-private-storage/private_storage/fields.py:88: UserWarning: CustomerDossierJoin.file.upload_subfolder should return a list to avoid path-separator issues.
  instance.__class__.__name__, self.name), UserWarning)
.......E
======================================================================
ERROR: private_storage.tests.test_imports (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: private_storage.tests.test_imports
Traceback (most recent call last):
  File "/Users/pavel.savchenko/github/django-private-storage/.tox/coverage/lib/python3.6/site-packages/storages/backends/s3boto3.py", line 27, in <module>
    import boto3.session
ModuleNotFoundError: No module named 'boto3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pavel.savchenko/.pyenv/versions/3.6.8/Python.framework/Versions/3.6/lib/python3.6/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/Users/pavel.savchenko/.pyenv/versions/3.6.8/Python.framework/Versions/3.6/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/Users/pavel.savchenko/github/django-private-storage/private_storage/tests/test_imports.py", line 9, in <module>
    import private_storage.storage.s3boto3
  File "/Users/pavel.savchenko/github/django-private-storage/private_storage/storage/s3boto3.py", line 8, in <module>
    from storages.backends.s3boto3 import S3Boto3Storage
  File "/Users/pavel.savchenko/github/django-private-storage/.tox/coverage/lib/python3.6/site-packages/storages/backends/s3boto3.py", line 32, in <module>
    raise ImproperlyConfigured("Could not load Boto3's S3 bindings.\n"
django.core.exceptions.ImproperlyConfigured: Could not load Boto3's S3 bindings.
See https://github.com/boto/boto3
```

(and the equivalent for Django if it's also missing)