### PR TITLE
Use 'six' API directly

### DIFF
--- a/private_storage/fields.py
+++ b/private_storage/fields.py
@@ -7,13 +7,14 @@ import os
 import posixpath
 import warnings
 
+from six import string_types
+
 import django
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import UploadedFile
 from django.db import models
 from django.template.defaultfilters import filesizeformat
 from django.utils.encoding import force_str, force_text
-from django.utils.six import string_types
 from django.utils.translation import ugettext_lazy as _
 
 from .storage import private_storage


### PR DESCRIPTION
As Django 3 drops compatibility with Python 2.7 and removes a number of
private APIs, importing `django.utils.six` is no longer possible, but
`string_types` can be imported from `six` directly.

Note that this change is compatible with Python 2.7, meaning
`django-private-storage` would stay compatible with Python 2.7 if this
commit is merged.