### PR TITLE
Add missing dependencies to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ deps =
     django110: Django >= 1.10,<1.11
     django111: Django >= 1.11,<1.12
     django20: Django >= 2.0,<2.1
+    django21: Django >= 2.1,<2.2
+    django22: Django >= 2.2,<2.3
     django-dev: https://github.com/django/django/tarball/master
 commands=
     python runtests.py


### PR DESCRIPTION
As the `deps` for `django21` and `django22` were undefined, `tox` ended
up installing the latests version of Django in the environment instead.