### PR TITLE
Use 'lru_cache' from 'functools'

### DIFF
--- a/private_storage/servers.py
+++ b/private_storage/servers.py
@@ -4,13 +4,12 @@ Sending files efficiently for different kind of webservers.
 import os
 import sys
 import time
-from functools import wraps
+from functools import lru_cache, wraps
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import FileResponse, HttpResponse, HttpResponseNotModified
 from django.utils.http import http_date
-from django.utils.lru_cache import lru_cache
 from django.utils.module_loading import import_string
 from django.views.static import serve, was_modified_since
 


### PR DESCRIPTION
As Django 3 drops compatibility with Python 2.7 and removes a number of
private APIs, importing `django.utils.lru_cache` is no longer possible, but
`lru_cache` can be imported from `functools` instead.

Note that while this change is compatible with all *Django* versions
down to 1.8, it breaks compatibility of `django-private-storage` with
Python 2.7 as `lru_cache` was not introduced to `functools` until Python
3.2.

Merging both #42 and this PR would make `django-private-storage` work
with Django 3 (AFAICT, at least the unit tests succeed), but at the
price of losing compatibility with Python 2.7.