### PR TITLE
compatibility six and lru_cache compatibility

### DIFF
--- a/private_storage/fields.py
+++ b/private_storage/fields.py
@@ -13,7 +13,12 @@ from django.core.files.uploadedfile import UploadedFile
 from django.db import models
 from django.template.defaultfilters import filesizeformat
 from django.utils.encoding import force_str, force_text
-from django.utils.six import string_types
+
+try:
+    from django.utils.six import string_types
+except ImportError:
+    from six import string_types
+
 from django.utils.translation import ugettext_lazy as _
 
 from .storage import private_storage

--- a/private_storage/servers.py
+++ b/private_storage/servers.py
@@ -10,7 +10,10 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import FileResponse, HttpResponse, HttpResponseNotModified
 from django.utils.http import http_date
-from django.utils.lru_cache import lru_cache
+try:
+    from django.utils.lru_cache import lru_cache
+except ImportError:
+    from functools import lru_cache
 from django.utils.module_loading import import_string
 from django.views.static import serve, was_modified_since
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ setup(
     version=find_version('private_storage', '__init__.py'),
     license='Apache 2.0',
 
-    install_requires=[],
+    install_requires=[
+        'six'
+    ],
     requires=[
         'Django (>=1.7.4)',
     ],


### PR DESCRIPTION
I have easily solved compatibility issues with the latest versions of Django and Python. I simply add` try: except ImportError: `statements to some conflicting `import`.


It should not cause absolutely any compatibility issues with previous versions.