### PR TITLE
change `url` by `path`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Add to ``urls.py``:
     import private_storage.urls
 
     urlpatterns += [
-        url('^private-media/', include(private_storage.urls)),
+        path('private-media/', include(private_storage.urls)),
     ]
 
 Usage


### PR DESCRIPTION
### Motivation

* [The url() function](https://docs.djangoproject.com/en/3.1/ref/urls/) in django has been deprecated since version 3.1.

### This PR

* This PR changes `readme.md` to use `path` instead of `url`