### PR TITLE
Bugfix with Django 4.2

### DIFF
--- a/private_storage/models.py
+++ b/private_storage/models.py
@@ -1,6 +1,6 @@
 import mimetypes
 
-from django.core.files.storage import File, Storage
+#from django.core.files.storage import File, Storage
 from django.utils.functional import cached_property
 
 


### PR DESCRIPTION
There are unused imports than raise error with Django 4.2
from django.core.files.storage import File, Storage 
ImportError: cannot import name 'File' from 'django.core.files.storage'