### PR TITLE
Support django-storages >=1.14 (Amazon S3)

### DIFF
--- a/private_storage/storage/s3boto3.py
+++ b/private_storage/storage/s3boto3.py
@@ -16,8 +16,8 @@ class PrivateS3BotoStorage(S3Boto3Storage):
     Private storage bucket for S3
     """
 
-    access_key_names = ['AWS_PRIVATE_S3_ACCESS_KEY_ID', 'AWS_PRIVATE_ACCESS_KEY_ID'] + S3Boto3Storage.access_key_names
-    secret_key_names = ['AWS_PRIVATE_S3_SECRET_ACCESS_KEY', 'AWS_PRIVATE_SECRET_ACCESS_KEY'] + S3Boto3Storage.secret_key_names
+    access_key_names = ['AWS_PRIVATE_S3_ACCESS_KEY_ID', 'AWS_PRIVATE_ACCESS_KEY_ID'] + getattr(S3Boto3Storage, 'access_key_names', [])
+    secret_key_names = ['AWS_PRIVATE_S3_SECRET_ACCESS_KEY', 'AWS_PRIVATE_SECRET_ACCESS_KEY'] + getattr(S3Boto3Storage, 'secret_key_names', [])
 
     def __init__(self, **settings):
         super().__init__(**settings)

--- a/private_storage/storage/s3boto3.py
+++ b/private_storage/storage/s3boto3.py
@@ -16,8 +16,8 @@ class PrivateS3BotoStorage(S3Boto3Storage):
     Private storage bucket for S3
     """
 
-    access_key_names = ['AWS_PRIVATE_S3_ACCESS_KEY_ID', 'AWS_PRIVATE_ACCESS_KEY_ID'] + getattr(S3Boto3Storage, 'access_key_names', [])
-    secret_key_names = ['AWS_PRIVATE_S3_SECRET_ACCESS_KEY', 'AWS_PRIVATE_SECRET_ACCESS_KEY'] + getattr(S3Boto3Storage, 'secret_key_names', [])
+    #access_key_names = ['AWS_PRIVATE_S3_ACCESS_KEY_ID', 'AWS_PRIVATE_ACCESS_KEY_ID'] + getattr(S3Boto3Storage, 'access_key_names', [])
+    #secret_key_names = ['AWS_PRIVATE_S3_SECRET_ACCESS_KEY', 'AWS_PRIVATE_SECRET_ACCESS_KEY'] + getattr(S3Boto3Storage, 'secret_key_names', [])
 
     def __init__(self, **settings):
         super().__init__(**settings)


### PR DESCRIPTION
The `access_key_names` and `secret_key_names` attributes got removed from the `S3Boto3Storage`* class in the recent version of django-storages: https://github.com/jschneier/django-storages/commit/705bdb7300642f0c42d823e4e35eb20356579389#diff-421acfde5179532e21813bca0e6b91a717c16d3628f57b5a77c55e3afba6862fL256-L257

Accessing them directly in `PrivateS3BotoStorage` causes an `AttributeError`:

```
File ".../private_storage/storage/s3boto3.py", line 19, in PrivateS3BotoStorage
    access_key_names = ['AWS_PRIVATE_S3_ACCESS_KEY_ID', 'AWS_PRIVATE_ACCESS_KEY_ID'] + S3Boto3Storage.access_key_names
AttributeError: type object 'S3Storage' has no attribute 'access_key_names'
```

> \*It's now `S3Storage`, but the [changelog says](https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#114-2023-09-04) we can keep using the old names, so these changes should be enough for now.